### PR TITLE
Update config to newest Alacritty version

### DIFF
--- a/dracula.yml
+++ b/dracula.yml
@@ -1,24 +1,7 @@
-# ...
-
-# Colors (Dracula)
 colors:
-  # Default colors
   primary:
     background: '0x282a36'
     foreground: '0xf8f8f2'
-
-    # Bright and dim foreground colors
-    #
-    # The dimmed foreground color is calculated automatically if it is not present.
-    # If the bright foreground color is not set, or `draw_bold_text_with_bright_colors`
-    # is `false`, the normal foreground color will be used.
-    #dim_foreground: '0x9a9a9a'
-    #bright_foreground: '0xffffff'
-
-  # Cursor colors
-  #
-  # Colors which should be used to draw the terminal cursor. If these are unset,
-  # the cursor color will be the inverse of the cell color.
   cursor:
     text: CellBackground
     cursor: CellForeground
@@ -38,16 +21,9 @@ colors:
   line_indicator:
     foreground: None
     background: None
-  # Selection colors
-  #
-  # Colors which should be used to draw the selection area. If selection
-  # background is unset, selection color will be the inverse of the cell colors.
-  # If only text is unset the cell text color will remain the same.
   selection:
     text: CellForeground
     background: '0x44475a'
-
-  # Normal colors
   normal:
     black:   '0x000000'
     red:     '0xff5555'
@@ -57,8 +33,6 @@ colors:
     magenta: '0xff79c6'
     cyan:    '0x8be9fd'
     white:   '0xbfbfbf'
-
-  # Bright colors
   bright:
     black:   '0x4d4d4d'
     red:     '0xff6e67'
@@ -68,11 +42,6 @@ colors:
     magenta: '0xff92d0'
     cyan:    '0x9aedfe'
     white:   '0xe6e6e6'
-
-  # Dim colors
-  #
-  # If the dim colors are not set, they will be calculated automatically based
-  # on the `normal` colors.
   dim:
     black:   '0x14151b'
     red:     '0xff2222'
@@ -82,16 +51,3 @@ colors:
     magenta: '0xff46b0'
     cyan:    '0x59dffc'
     white:   '0xe6e6d1'
-
-  # Indexed Colors
-  #
-  # The indexed colors include all colors from 16 to 256.
-  # When these are not set, they're filled with sensible defaults.
-  #
-  # Example:
-  #   `- { index: 16, color: '0xff00ff' }`
-  #
-  indexed_colors: []
-
-# Visual Bell
-# ...

--- a/dracula.yml
+++ b/dracula.yml
@@ -20,8 +20,8 @@ colors:
   # Colors which should be used to draw the terminal cursor. If these are unset,
   # the cursor color will be the inverse of the cell color.
   cursor:
-    text: '0x44475a'
-    cursor: '0xf8f8f2'
+    text: CellBackground
+    cursor: CellForeground
 
   # Selection colors
   #

--- a/dracula.yml
+++ b/dracula.yml
@@ -22,7 +22,22 @@ colors:
   cursor:
     text: CellBackground
     cursor: CellForeground
-
+  vi_mode_cursor:
+    text: CellBackground
+    cursor: CellForeground
+  search:
+    matches:
+      foreground: '0x44475a'
+      background: '0x50fa7b'
+    focused_match:
+      foreground: '0x44475a'
+      background: '0xffb86c'
+    bar:
+      background: '0x282a36'
+      foreground: '0xf8f8f2'
+  line_indicator:
+    foreground: None
+    background: None
   # Selection colors
   #
   # Colors which should be used to draw the selection area. If selection

--- a/dracula.yml
+++ b/dracula.yml
@@ -44,7 +44,7 @@ colors:
   # background is unset, selection color will be the inverse of the cell colors.
   # If only text is unset the cell text color will remain the same.
   selection:
-    text: '0xf8f8f2'
+    text: CellForeground
     background: '0x44475a'
 
   # Normal colors


### PR DESCRIPTION
This update adds new color options that were added on the last releases of Alacritty.
I tried to match the colors used on the vim plugin.

_Search bar and highlights_
<img width="1326" alt="Screenshot 2021-01-09 at 00 47 53" src="https://user-images.githubusercontent.com/554507/104076506-8e97c000-5216-11eb-854b-835fa367e219.png">

_Vim mode line highlight_
<img width="1326" alt="Screenshot 2021-01-09 at 01 07 40" src="https://user-images.githubusercontent.com/554507/104076689-1c73ab00-5217-11eb-906a-0a14d0ee7279.png">

