### PR TITLE
Make theme fully spec‐compliant

### DIFF
--- a/dracula.yml
+++ b/dracula.yml
@@ -26,8 +26,8 @@ colors:
       foreground: '#44475a'
       background: '#ffb86c'
     bar:
-      background: '#f8f8f2'
-      foreground: '#282a36'
+      background: '#282a36'
+      foreground: '#f8f8f2'
   hints:
     start:
       foreground: '#282a36'


### PR DESCRIPTION
- Added links to references (it’s very handy to have them at hand to keep with the updates).
- Updated template (sync with [master][`alacritty.yml`]).
- Switched to web color notation (`#rrggbb`).
- Removed dim colors, as they are not in the [spec][color palette] and calculated automatically.

[Color palette]: https://spec.draculatheme.com
[`alacritty.yml`]: https://github.com/alacritty/alacritty/blob/master/alacritty.yml