### PR TITLE
alacritty 0.11 deprecate colors.search.bar

### DIFF
--- a/dracula.yml
+++ b/dracula.yml
@@ -25,9 +25,9 @@ colors:
     focused_match:
       foreground: '#44475a'
       background: '#ffb86c'
-    bar:
-      background: '#282a36'
-      foreground: '#f8f8f2'
+  footer_bar:
+    background: '#282a36'
+    foreground: '#f8f8f2'
   hints:
     start:
       foreground: '#282a36'


### PR DESCRIPTION
Deprecated colors.search.bar, use colors.footer_bar instead
https://github.com/alacritty/alacritty/commit/694a52bcffeffdc9e163818c3b2ac5c39e26f1ef

